### PR TITLE
 tf.app removed from tensorflow-2.0.0, argument large nonexistent in resnet50.py

### DIFF
--- a/RepNet/requirements.txt
+++ b/RepNet/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.16.4
 six==1.12.0
 scikit_learn==0.21.3
-tensorflow==2.0.0
+tensorflow==1.13.1

--- a/RepNet/resnet50.py
+++ b/RepNet/resnet50.py
@@ -117,8 +117,8 @@ def inputs():
   return images, labels, edges, ignore, poss_lbls
 
 
-def test_inputs(large=False):
-  image, filenames = resnet50_input.test_inputs(FLAGS.data_dir, large=large)
+def test_inputs():
+  image, filenames = resnet50_input.test_inputs(FLAGS.data_dir)
   return image, filenames
   
 


### PR DESCRIPTION
The error faced when running resnet_50_eval.py and using tf.app.run()/tf.app.flags()

AttributeError: module 'tensorflow' has no attribute 'app'

tensorflow 2.x removed tf.app and hence version downgraded to 1.13.1